### PR TITLE
docs: publish the existing trilingual docs as a searchable GitHub Pages site (2 files)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,48 @@
+name: docs
+
+# Docs-as-code: kura.toml + this workflow. The kurajs/pages action renders the docs into a
+# TRILINGUAL static site (en / zh-cn / ko — the repo already maintains the translations) with
+# client-side search per language, images, and agent surfaces (.md + llms.txt + MCP). The repo's
+# docs/ is never modified: this workflow shapes a BUILD COPY (.docs-site) because Kura's i18n
+# convention wants top-level locale mirrors (docs here nest them per-folder as user-guide/zh-cn).
+
+on:
+  push:
+    branches: [main, docs/kura-site]
+    paths:
+      - "docs/**"
+      - "kura.toml"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: docs-pages
+  cancel-in-progress: false
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Shape the build copy (top-level locale mirrors; repo untouched)
+        run: |
+          mkdir -p .docs-site/zh-cn .docs-site/ko
+          cp -R docs/user-guide .docs-site/user-guide
+          cp -R docs/reference  .docs-site/reference
+          # the per-folder mirrors become Kura's top-level <locale>/ mirrors
+          mv .docs-site/user-guide/zh-cn .docs-site/zh-cn/user-guide
+          mv .docs-site/user-guide/ko    .docs-site/ko/user-guide
+          rm -f .docs-site/user-guide/TODO.ko.md
+          # the mirrors' image geometry followed the OLD layout (../images); after the move the
+          # shared images live one level differently — same-src as the default file resolves them
+          grep -rl '](../images/' .docs-site/zh-cn .docs-site/ko 2>/dev/null | while read -r f; do
+            sed -i 's#](\.\./images/#](./images/#g' "$f"
+          done
+
+      - uses: kurajs/pages@v1
+        with:
+          docs: .docs-site

--- a/kura.toml
+++ b/kura.toml
@@ -1,0 +1,29 @@
+# model-compose docs site — the ONLY config. The kurajs/pages action reads this and renders the
+# repo's docs/ into a trilingual (en / 简体中文 / 한국어), searchable, agent-native static site.
+# The workflow shapes a build copy (.docs-site) so the repo's docs/ is never modified.
+
+markdown  = "commonmark"
+base_path = ""
+
+[site]
+name        = "model-compose"
+description = "Portable AI runtime inspired by docker-compose: compose agents, RAG pipelines, and MCP servers in one YAML file."
+
+[deploy]
+target = "github-pages"
+
+[content]
+sources = []
+
+[i18n]
+default_locale = "en"
+[i18n.locales.en]
+[i18n.locales.zh-cn]
+path = "/zh-cn"
+[i18n.locales.ko]
+path = "/ko"
+
+[locale_names]
+en = "English"
+zh-cn = "简体中文"
+ko = "한국어"

--- a/kura.toml
+++ b/kura.toml
@@ -27,3 +27,46 @@ path = "/ko"
 en = "English"
 zh-cn = "简体中文"
 ko = "한국어"
+
+# Virtual navigation: two reading modes, two tabs. Page labels are bare slugs so each locale keeps
+# its own translated titles in the sidebar; groups without pages auto-fill from their folder.
+[[nav.tabs]]
+title = "User Guide"
+groups = ["user-guide"]
+
+[[nav.tabs]]
+title = "Reference"
+groups = ["compose-file", "reference/compose/components", "interfaces"]
+
+[nav.groups.user-guide]
+title = "User Guide"
+
+[nav.groups.compose-file]
+title = "Compose File"
+pages = [
+  "reference/compose",
+  "reference/compose/component",
+  "reference/compose/workflow",
+  "reference/compose/controller",
+  "reference/compose/gateway",
+  "reference/compose/listener",
+  "reference/compose/logger",
+  "reference/compose/tracer",
+  "reference/compose/system",
+  "reference/compose/language-codes",
+]
+
+[nav.groups."reference/compose/components"]
+title = "Components"
+
+[nav.groups.interfaces]
+title = "CLI & Interfaces"
+pages = ["reference/cli", "reference/websocket"]
+
+[tab_labels.zh-cn]
+"User Guide" = "用户指南"
+"Reference" = "参考"
+
+[tab_labels.ko]
+"User Guide" = "사용자 가이드"
+"Reference" = "레퍼런스"


### PR DESCRIPTION
Hi! model-compose has some of the most complete docs I have run into lately: a 19-chapter user guide, a full component reference, and maintained zh-cn and ko translations. They deserve more than raw markdown on GitHub, so I built a docs site from them and I would love to contribute it back.

**Live preview (built from this branch, one page per language):**

- English: https://linyiru.github.io/model-compose/
- 简体中文: https://linyiru.github.io/model-compose/zh-cn/
- 한국어: https://linyiru.github.io/model-compose/ko/

## What you get

- **Trilingual site from your existing translations.** The language switcher (top right) swaps any page to its translation. Untranslated pages (the reference section) fall back to English while staying reachable in every language, and flip automatically the moment a translation lands in the mirror.
- **Search is split per language.** Each locale ships its own search index: searching on the Chinese site matches the Chinese text (with CJK-aware tokenization, so queries like 工作流配置 work), Korean matches Korean, and untranslated pages remain findable via their English text. Try the search box (or press /) on each preview above.
- **Two reading modes as tabs.** User Guide and Reference are separate tabs with their own sidebars, and the tab labels are localized (用户指南 / 参考, 사용자 가이드 / 레퍼런스).
- **Images work.** The Web UI screenshot in chapter 1 is served on all three languages.
- **Agent-friendly out of the box.** Every page also exists as plain markdown (append .md to any URL, or use the Copy Markdown button), plus /llms.txt and an MCP endpoint, so AI assistants can consume the docs directly.

## What this PR contains

Just two files, and your docs/ directory is never modified:

- `kura.toml`: the site config (name, languages, navigation).
- `.github/workflows/docs.yml`: builds and deploys on every docs push. Because this repo nests translations per folder (docs/user-guide/zh-cn) while the site convention wants top-level locale mirrors, the workflow shapes a temporary build copy in CI and adjusts the relative image paths there. The repository itself stays untouched.

## After merging

1. Merge this PR (the workflow creates a gh-pages branch on the first run).
2. In Settings > Pages, set the source to the gh-pages branch, / (root).
3. The site publishes at `https://hanyeol.github.io/model-compose/` and rebuilds automatically whenever docs/ or the translations change on main.

Happy to adjust anything: navigation grouping, site name, or dropping the workflow trigger on this branch name (it is only there so the preview builds). If you would rather not take this, no hard feelings, and thanks for the project!