### PR TITLE
Pin mcp dependency below 2.0 to keep FastMCP import working

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "fastapi",
     "websockets",
     "uvicorn",
-    "mcp>=1.10.1",
+    "mcp>=1.10.1,<2.0",
     "ulid",
     "Pillow",
     "async_timeout>=4.0; python_version < '3.11'"

--- a/src/mindor/core/runtime/bootstrap/requirements.txt
+++ b/src/mindor/core/runtime/bootstrap/requirements.txt
@@ -11,7 +11,7 @@ requests
 fastapi
 websockets
 uvicorn
-mcp>=1.10.1
+mcp>=1.10.1,<2.0
 ulid
 Pillow
 async_timeout>=4.0; python_version < '3.11'


### PR DESCRIPTION
## WHY
mcp 2.0.0 removed the mcp.server.fastmcp module (and the FastMCP class entirely), which src/mindor/core/controller/adapters/services/mcp_server.py imports directly. Both pyproject.toml and the runtime bootstrap requirements.txt declared only "mcp>=1.10.1" with no upper bound, so a fresh install resolves to 2.0.0 and the mcp-server controller adapter fails at import time with ModuleNotFoundError: No module named 'mcp.server.fastmcp'.

## HOW
Pin mcp to <2.0 in both pyproject.toml and requirements.txt. Verified by reinstalling mcp==2.0.0 and confirming FastMCP is absent from every submodule under mcp.server in that release