### PR TITLE
Fix local file-store file:// URLs breaking on Windows paths

### DIFF
--- a/src/mindor/core/component/services/file_store/drivers/local.py
+++ b/src/mindor/core/component/services/file_store/drivers/local.py
@@ -11,7 +11,7 @@ from mindor.core.utils.time import format_datetime_iso_string
 from ..base import FileStoreService, FileStoreDriver, register_file_store_service
 from ..base import ComponentActionContext
 from .common import FileStoreAction
-import aiofiles, os, stat as stat_module, sys, urllib.parse
+import aiofiles, os, pathlib, stat as stat_module, sys
 
 _DEFAULT_CHUNK_SIZE = 8 * 1024 * 1024  # 8MB — for put and save_to downloads
 _DEFAULT_STREAMING_CHUNK_SIZE = 8 * 1024  # 8KB — for streaming output, matching other StreamResources
@@ -233,7 +233,7 @@ class LocalFileStoreAction(FileStoreAction):
         return os.path.normpath(os.path.join(self.base_path, path))
 
     def _build_file_url(self, absolute_path: str) -> str:
-        return f"file://{urllib.parse.quote(os.path.abspath(absolute_path))}"
+        return pathlib.Path(absolute_path).as_uri()
 
 @register_file_store_service(FileStoreDriver.LOCAL)
 class LocalFileStoreService(FileStoreService):


### PR DESCRIPTION
## WHY
_build_file_url() quoted os.path.abspath() output before prefixing it with "file://". On Windows, abspath() returns backslash-separated paths (e.g. "D:\output\audio"), and urllib.parse.quote() percent-encodes both the backslashes and the drive-letter colon, leaving no "/" characters in the result. urlparse() then reads the whole encoded path as netloc and returns an empty path, so any downstream component that re-reads the file via its URL (audio-feature-extractor, video-encoder, etc.) fails with FileNotFoundError on an empty path.

## HOW
Use pathlib.Path.as_uri() instead, which produces a correct file:// URI on both Windows and POSIX (e.g. "file:///D:/output/audio") and round-trips correctly with url2pathname(). Verified by rerunning examples/media-processing/audio-spectrum-to-video on Windows end-to-end (save-audio -> spectrum -> frames -> encode), which previously failed instantly with FileNotFoundError: [WinError 3]