### PR TITLE
Remove broken manual Content-Type header from README curl examples

### DIFF
--- a/examples/media-processing/audio-extractor/README.ko.md
+++ b/examples/media-processing/audio-extractor/README.ko.md
@@ -50,7 +50,6 @@
    **API 사용:**
    ```bash
    curl -X POST http://localhost:8080/api/workflows/runs \
-     -H "Content-Type: multipart/form-data" \
      -F "source=@input.mp4" \
      -F "format=mp3" \
      -F "codec=libmp3lame" \

--- a/examples/media-processing/audio-extractor/README.md
+++ b/examples/media-processing/audio-extractor/README.md
@@ -50,7 +50,6 @@ This workflow provides an audio extraction service that:
    **Using API:**
    ```bash
    curl -X POST http://localhost:8080/api/workflows/runs \
-     -H "Content-Type: multipart/form-data" \
      -F "source=@input.mp4" \
      -F "format=mp3" \
      -F "codec=libmp3lame" \

--- a/examples/media-processing/audio-extractor/README.zh-cn.md
+++ b/examples/media-processing/audio-extractor/README.zh-cn.md
@@ -50,7 +50,6 @@
    **使用 API：**
    ```bash
    curl -X POST http://localhost:8080/api/workflows/runs \
-     -H "Content-Type: multipart/form-data" \
      -F "source=@input.mp4" \
      -F "format=mp3" \
      -F "codec=libmp3lame" \

--- a/examples/media-processing/audio-feature-extractor/README.ko.md
+++ b/examples/media-processing/audio-feature-extractor/README.ko.md
@@ -52,14 +52,12 @@
    ```bash
    # Spectrum (기본 워크플로우)
    curl -X POST http://localhost:8080/api/workflows/runs \
-     -H "Content-Type: multipart/form-data" \
      -F "audio=@song.mp3" \
      -F "fps=30" \
      -F "band_count=32"
 
    # Waveform
    curl -X POST http://localhost:8080/api/workflows/runs \
-     -H "Content-Type: multipart/form-data" \
      -F "workflow_id=waveform" \
      -F "audio=@song.mp3" \
      -F "fps=30" \

--- a/examples/media-processing/audio-feature-extractor/README.md
+++ b/examples/media-processing/audio-feature-extractor/README.md
@@ -52,14 +52,12 @@ The output is a JSON payload with a `frames` array. Each entry is one video fram
    ```bash
    # Spectrum (default workflow)
    curl -X POST http://localhost:8080/api/workflows/runs \
-     -H "Content-Type: multipart/form-data" \
      -F "audio=@song.mp3" \
      -F "fps=30" \
      -F "band_count=32"
 
    # Waveform
    curl -X POST http://localhost:8080/api/workflows/runs \
-     -H "Content-Type: multipart/form-data" \
      -F "workflow_id=waveform" \
      -F "audio=@song.mp3" \
      -F "fps=30" \

--- a/examples/media-processing/audio-feature-extractor/README.zh-cn.md
+++ b/examples/media-processing/audio-feature-extractor/README.zh-cn.md
@@ -52,14 +52,12 @@
    ```bash
    # Spectrum（默认工作流）
    curl -X POST http://localhost:8080/api/workflows/runs \
-     -H "Content-Type: multipart/form-data" \
      -F "audio=@song.mp3" \
      -F "fps=30" \
      -F "band_count=32"
 
    # Waveform
    curl -X POST http://localhost:8080/api/workflows/runs \
-     -H "Content-Type: multipart/form-data" \
      -F "workflow_id=waveform" \
      -F "audio=@song.mp3" \
      -F "fps=30" \

--- a/examples/media-processing/audio-spectrum-to-video/README.ko.md
+++ b/examples/media-processing/audio-spectrum-to-video/README.ko.md
@@ -80,7 +80,6 @@ cd examples/media-processing/audio-spectrum-to-video
 
    ```bash
    curl -X POST http://localhost:8080/api/render \
-     -H 'Content-Type: multipart/form-data' \
      -F 'input.audio=@./song.mp3' \
      -F 'input.fps=30' \
      -F 'input.band_count=48'

--- a/examples/media-processing/audio-spectrum-to-video/README.md
+++ b/examples/media-processing/audio-spectrum-to-video/README.md
@@ -83,7 +83,6 @@ Have an audio file ready (mp3, wav, flac, ogg, opus, or aac).
 
    ```bash
    curl -X POST http://localhost:8080/api/render \
-     -H 'Content-Type: multipart/form-data' \
      -F 'input.audio=@./song.mp3' \
      -F 'input.fps=30' \
      -F 'input.band_count=48'

--- a/examples/media-processing/audio-spectrum-to-video/README.zh-cn.md
+++ b/examples/media-processing/audio-spectrum-to-video/README.zh-cn.md
@@ -78,7 +78,6 @@ cd examples/media-processing/audio-spectrum-to-video
 
    ```bash
    curl -X POST http://localhost:8080/api/render \
-     -H 'Content-Type: multipart/form-data' \
      -F 'input.audio=@./song.mp3' \
      -F 'input.fps=30' \
      -F 'input.band_count=48'

--- a/examples/media-processing/image-processor-dual-input/README.ko.md
+++ b/examples/media-processing/image-processor-dual-input/README.ko.md
@@ -57,7 +57,6 @@
 
    # 파일 업로드
    curl -X POST http://localhost:8080/api/workflows/runs \
-     -H "Content-Type: multipart/form-data" \
      -F "workflow_id=resize-from-upload" \
      -F "image=@photo.jpg" \
      -F "width=512" \

--- a/examples/media-processing/image-processor-dual-input/README.md
+++ b/examples/media-processing/image-processor-dual-input/README.md
@@ -57,7 +57,6 @@ Inside the component action both paths are received as `${input.image as image}`
 
    # File upload
    curl -X POST http://localhost:8080/api/workflows/runs \
-     -H "Content-Type: multipart/form-data" \
      -F "workflow_id=resize-from-upload" \
      -F "image=@photo.jpg" \
      -F "width=512" \

--- a/examples/media-processing/image-processor-dual-input/README.zh-cn.md
+++ b/examples/media-processing/image-processor-dual-input/README.zh-cn.md
@@ -57,7 +57,6 @@
 
    # 文件上传
    curl -X POST http://localhost:8080/api/workflows/runs \
-     -H "Content-Type: multipart/form-data" \
      -F "workflow_id=resize-from-upload" \
      -F "image=@photo.jpg" \
      -F "width=512" \

--- a/examples/media-processing/image-processor/README.ko.md
+++ b/examples/media-processing/image-processor/README.ko.md
@@ -47,7 +47,6 @@
    ```bash
    # 이미지 크기 조정
    curl -X POST http://localhost:8080/api/workflows/runs \
-     -H "Content-Type: multipart/form-data" \
      -F "workflow_id=resize" \
      -F "image=@input.png" \
      -F "width=800" \
@@ -56,14 +55,12 @@
 
    # 가우시안 블러 적용
    curl -X POST http://localhost:8080/api/workflows/runs \
-     -H "Content-Type: multipart/form-data" \
      -F "workflow_id=blur" \
      -F "image=@input.png" \
      -F "radius=5.0"
 
    # 그레이스케일 변환
    curl -X POST http://localhost:8080/api/workflows/runs \
-     -H "Content-Type: multipart/form-data" \
      -F "workflow_id=grayscale" \
      -F "image=@input.png"
    ```

--- a/examples/media-processing/image-processor/README.md
+++ b/examples/media-processing/image-processor/README.md
@@ -47,7 +47,6 @@ This workflow provides image processing capabilities that:
    ```bash
    # Resize an image
    curl -X POST http://localhost:8080/api/workflows/runs \
-     -H "Content-Type: multipart/form-data" \
      -F "workflow_id=resize" \
      -F "image=@input.png" \
      -F "width=800" \
@@ -56,14 +55,12 @@ This workflow provides image processing capabilities that:
 
    # Apply Gaussian blur
    curl -X POST http://localhost:8080/api/workflows/runs \
-     -H "Content-Type: multipart/form-data" \
      -F "workflow_id=blur" \
      -F "image=@input.png" \
      -F "radius=5.0"
 
    # Convert to grayscale
    curl -X POST http://localhost:8080/api/workflows/runs \
-     -H "Content-Type: multipart/form-data" \
      -F "workflow_id=grayscale" \
      -F "image=@input.png"
    ```

--- a/examples/media-processing/image-processor/README.zh-cn.md
+++ b/examples/media-processing/image-processor/README.zh-cn.md
@@ -47,7 +47,6 @@
    ```bash
    # 调整图像大小
    curl -X POST http://localhost:8080/api/workflows/runs \
-     -H "Content-Type: multipart/form-data" \
      -F "workflow_id=resize" \
      -F "image=@input.png" \
      -F "width=800" \
@@ -56,14 +55,12 @@
 
    # 应用高斯模糊
    curl -X POST http://localhost:8080/api/workflows/runs \
-     -H "Content-Type: multipart/form-data" \
      -F "workflow_id=blur" \
      -F "image=@input.png" \
      -F "radius=5.0"
 
    # 转换为灰度
    curl -X POST http://localhost:8080/api/workflows/runs \
-     -H "Content-Type: multipart/form-data" \
      -F "workflow_id=grayscale" \
      -F "image=@input.png"
    ```

--- a/examples/media-processing/video-converter/README.ko.md
+++ b/examples/media-processing/video-converter/README.ko.md
@@ -49,7 +49,6 @@
    **API 사용:**
    ```bash
    curl -X POST http://localhost:8080/api/workflows/runs \
-     -H "Content-Type: multipart/form-data" \
      -F "video=@input.mov" \
      -F "format=mp4" \
      -F "codec=libx264" \

--- a/examples/media-processing/video-converter/README.md
+++ b/examples/media-processing/video-converter/README.md
@@ -49,7 +49,6 @@ This workflow provides a video conversion service that:
    **Using API:**
    ```bash
    curl -X POST http://localhost:8080/api/workflows/runs \
-     -H "Content-Type: multipart/form-data" \
      -F "video=@input.mov" \
      -F "format=mp4" \
      -F "codec=libx264" \

--- a/examples/media-processing/video-converter/README.zh-cn.md
+++ b/examples/media-processing/video-converter/README.zh-cn.md
@@ -49,7 +49,6 @@
    **使用 API：**
    ```bash
    curl -X POST http://localhost:8080/api/workflows/runs \
-     -H "Content-Type: multipart/form-data" \
      -F "video=@input.mov" \
      -F "format=mp4" \
      -F "codec=libx264" \

--- a/examples/model-providers/openai/openai-audio-transciptions/README.ko.md
+++ b/examples/model-providers/openai/openai-audio-transciptions/README.ko.md
@@ -53,7 +53,6 @@
    **API 사용:**
    ```bash
    curl -X POST http://localhost:8080/api/workflows/runs \
-     -H "Content-Type: multipart/form-data" \
      -F "input={\"file\": \"@audio\"}" \
      -F "audio=@sample_audio.mp3"
    ```

--- a/examples/model-providers/openai/openai-audio-transciptions/README.md
+++ b/examples/model-providers/openai/openai-audio-transciptions/README.md
@@ -53,7 +53,6 @@ This workflow provides advanced speech-to-text capabilities that:
    **Using API:**
    ```bash
    curl -X POST http://localhost:8080/api/workflows/runs \
-     -H "Content-Type: multipart/form-data" \
      -F "input={\"file\": \"@audio\"}" \
      -F "audio=@sample_audio.mp3"
    ```

--- a/examples/model-providers/openai/openai-audio-transciptions/README.zh-cn.md
+++ b/examples/model-providers/openai/openai-audio-transciptions/README.zh-cn.md
@@ -53,7 +53,6 @@
    **使用 API：**
    ```bash
    curl -X POST http://localhost:8080/api/workflows/runs \
-     -H "Content-Type: multipart/form-data" \
      -F "input={\"file\": \"@audio\"}" \
      -F "audio=@sample_audio.mp3"
    ```

--- a/examples/model-providers/openai/openai-image-edits/README.ko.md
+++ b/examples/model-providers/openai/openai-image-edits/README.ko.md
@@ -53,7 +53,6 @@
    **API 사용:**
    ```bash
    curl -X POST http://localhost:8080/api/workflows/runs \
-     -H "Content-Type: multipart/form-data" \
      -F "input={\"prompt\": \"Add a sunset background\", \"image\": \"@image\"}" \
      -F "image=@original.png"
    ```

--- a/examples/model-providers/openai/openai-image-edits/README.md
+++ b/examples/model-providers/openai/openai-image-edits/README.md
@@ -53,7 +53,6 @@ This workflow provides advanced image editing capabilities that:
    **Using API:**
    ```bash
    curl -X POST http://localhost:8080/api/workflows/runs \
-     -H "Content-Type: multipart/form-data" \
      -F "input={\"prompt\": \"Add a sunset background\", \"image\": \"@image\"}" \
      -F "image=@original.png"
    ```

--- a/examples/model-providers/openai/openai-image-edits/README.zh-cn.md
+++ b/examples/model-providers/openai/openai-image-edits/README.zh-cn.md
@@ -53,7 +53,6 @@
    **使用 API：**
    ```bash
    curl -X POST http://localhost:8080/api/workflows/runs \
-     -H "Content-Type: multipart/form-data" \
      -F "input={\"prompt\": \"添加日落背景\", \"image\": \"@image\"}" \
      -F "image=@original.png"
    ```

--- a/examples/model-providers/openai/openai-image-variations/README.ko.md
+++ b/examples/model-providers/openai/openai-image-variations/README.ko.md
@@ -53,7 +53,6 @@
    **API 사용:**
    ```bash
    curl -X POST http://localhost:8080/api/workflows/runs \
-     -H "Content-Type: multipart/form-data" \
      -F "input={\"image\": \"@image\"}" \
      -F "image=@source_image.png"
    ```

--- a/examples/model-providers/openai/openai-image-variations/README.md
+++ b/examples/model-providers/openai/openai-image-variations/README.md
@@ -53,7 +53,6 @@ This workflow provides AI-powered image variation capabilities that:
    **Using API:**
    ```bash
    curl -X POST http://localhost:8080/api/workflows/runs \
-     -H "Content-Type: multipart/form-data" \
      -F "input={\"image\": \"@image\"}" \
      -F "image=@source_image.png"
    ```

--- a/examples/model-providers/openai/openai-image-variations/README.zh-cn.md
+++ b/examples/model-providers/openai/openai-image-variations/README.zh-cn.md
@@ -53,7 +53,6 @@
    **使用 API：**
    ```bash
    curl -X POST http://localhost:8080/api/workflows/runs \
-     -H "Content-Type: multipart/form-data" \
      -F "input={\"image\": \"@image\"}" \
      -F "image=@source_image.png"
    ```

--- a/examples/model-tasks/image-background-removal/README.ko.md
+++ b/examples/model-tasks/image-background-removal/README.ko.md
@@ -59,7 +59,6 @@
    **API 사용:**
    ```bash
    curl -X POST http://localhost:8080/api/workflows/runs \
-     -H "Content-Type: multipart/form-data" \
      -F "image=@/path/to/your/input-image.jpg"
    ```
 

--- a/examples/model-tasks/image-background-removal/README.md
+++ b/examples/model-tasks/image-background-removal/README.md
@@ -59,7 +59,6 @@ Unlike cloud-based background removal APIs (remove.bg, Photoroom), local model e
    **Using API:**
    ```bash
    curl -X POST http://localhost:8080/api/workflows/runs \
-     -H "Content-Type: multipart/form-data" \
      -F "image=@/path/to/your/input-image.jpg"
    ```
 

--- a/examples/model-tasks/image-background-removal/README.zh-cn.md
+++ b/examples/model-tasks/image-background-removal/README.zh-cn.md
@@ -59,7 +59,6 @@
    **使用 API：**
    ```bash
    curl -X POST http://localhost:8080/api/workflows/runs \
-     -H "Content-Type: multipart/form-data" \
      -F "image=@/path/to/your/input-image.jpg"
    ```
 

--- a/examples/model-tasks/image-upscale/README.ko.md
+++ b/examples/model-tasks/image-upscale/README.ko.md
@@ -59,7 +59,6 @@
    **API 사용:**
    ```bash
    curl -X POST http://localhost:8080/api/workflows/runs \
-     -H "Content-Type: multipart/form-data" \
      -F "image=@/path/to/your/low-resolution-image.jpg"
    ```
 

--- a/examples/model-tasks/image-upscale/README.md
+++ b/examples/model-tasks/image-upscale/README.md
@@ -59,7 +59,6 @@ Unlike cloud-based image enhancement APIs, local model execution provides:
    **Using API:**
    ```bash
    curl -X POST http://localhost:8080/api/workflows/runs \
-     -H "Content-Type: multipart/form-data" \
      -F "image=@/path/to/your/low-resolution-image.jpg"
    ```
 

--- a/examples/model-tasks/image-upscale/README.zh-cn.md
+++ b/examples/model-tasks/image-upscale/README.zh-cn.md
@@ -59,7 +59,6 @@
    **使用 API：**
    ```bash
    curl -X POST http://localhost:8080/api/workflows/runs \
-     -H "Content-Type: multipart/form-data" \
      -F "image=@/path/to/your/low-resolution-image.jpg"
    ```
 

--- a/examples/showcase/find-person-scenes/README.ko.md
+++ b/examples/showcase/find-person-scenes/README.ko.md
@@ -52,7 +52,6 @@
    **API 사용:**
    ```bash
    curl -X POST http://localhost:8080/api/workflows/runs \
-     -H "Content-Type: multipart/form-data" \
      -F 'input={"similarity_threshold": 0.4, "frame_interval": 15};type=application/json' \
      -F 'target_face=@./target.jpg' \
      -F 'video=@./video.mp4'

--- a/examples/showcase/find-person-scenes/README.md
+++ b/examples/showcase/find-person-scenes/README.md
@@ -52,7 +52,6 @@ The strategy is:
    **Using API:**
    ```bash
    curl -X POST http://localhost:8080/api/workflows/runs \
-     -H "Content-Type: multipart/form-data" \
      -F 'input={"similarity_threshold": 0.4, "frame_interval": 15};type=application/json' \
      -F 'target_face=@./target.jpg' \
      -F 'video=@./video.mp4'

--- a/examples/showcase/find-person-scenes/README.zh-cn.md
+++ b/examples/showcase/find-person-scenes/README.zh-cn.md
@@ -52,7 +52,6 @@
    **使用 API：**
    ```bash
    curl -X POST http://localhost:8080/api/workflows/runs \
-     -H "Content-Type: multipart/form-data" \
      -F 'input={"similarity_threshold": 0.4, "frame_interval": 15};type=application/json' \
      -F 'target_face=@./target.jpg' \
      -F 'video=@./video.mp4'

--- a/examples/showcase/upscale-video/README.ko.md
+++ b/examples/showcase/upscale-video/README.ko.md
@@ -51,7 +51,6 @@
    **API 사용:**
    ```bash
    curl -X POST http://localhost:8080/api/workflows/runs \
-     -H "Content-Type: multipart/form-data" \
      -F 'input={"frame_rate": 30};type=application/json' \
      -F 'video=@./video.mp4'
    ```

--- a/examples/showcase/upscale-video/README.md
+++ b/examples/showcase/upscale-video/README.md
@@ -51,7 +51,6 @@ The strategy is:
    **Using API:**
    ```bash
    curl -X POST http://localhost:8080/api/workflows/runs \
-     -H "Content-Type: multipart/form-data" \
      -F 'input={"frame_rate": 30};type=application/json' \
      -F 'video=@./video.mp4'
    ```

--- a/examples/showcase/upscale-video/README.zh-cn.md
+++ b/examples/showcase/upscale-video/README.zh-cn.md
@@ -51,7 +51,6 @@
    **使用 API：**
    ```bash
    curl -X POST http://localhost:8080/api/workflows/runs \
-     -H "Content-Type: multipart/form-data" \
      -F 'input={"frame_rate": 30};type=application/json' \
      -F 'video=@./video.mp4'
    ```


### PR DESCRIPTION
## WHY
39 files combined curl's -F (multipart form) with an explicit -H 'Content-Type: multipart/form-data'. -F auto-generates a Content-Type header that includes the required boundary=... parameter; the manual -H overrides it with one that has no boundary, so the server can't parse the multipart body.

## HOW
Remove the redundant manual -H line so curl's auto-generated header (with boundary) is used, matching the many other examples that already worked this way