### PR TITLE
Pin mcp dependency below 2.0 to keep FastMCP import working

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "fastapi",
     "websockets",
     "uvicorn",
-    "mcp>=1.10.1",
+    "mcp>=1.10.1,<2.0",
     "ulid",
     "Pillow",
     "async_timeout>=4.0; python_version < '3.11'"

--- a/src/mindor/core/runtime/bootstrap/requirements.txt
+++ b/src/mindor/core/runtime/bootstrap/requirements.txt
@@ -11,7 +11,7 @@ requests
 fastapi
 websockets
 uvicorn
-mcp>=1.10.1
+mcp>=1.10.1,<2.0
 ulid
 Pillow
 async_timeout>=4.0; python_version < '3.11'


### PR DESCRIPTION
mcp>=2.0 breaks the FastMCP import path this project relies on. Pin `mcp` to `<2.0` in both `pyproject.toml` and the bootstrap `requirements.txt` so installs stay on a working version until the FastMCP import is updated for mcp 2.x.

- `pyproject.toml`: `mcp>=1.10.1` -> `mcp>=1.10.1,<2.0`
- `src/mindor/core/runtime/bootstrap/requirements.txt`: same change
