### PR TITLE
Fix dead /api/render endpoint in README curl examples

### DIFF
--- a/examples/media-processing/audio-spectrum-to-video/README.ko.md
+++ b/examples/media-processing/audio-spectrum-to-video/README.ko.md
@@ -79,7 +79,8 @@ cd examples/media-processing/audio-spectrum-to-video
    http://localhost:8081의 Gradio UI 또는 HTTP로:
 
    ```bash
-   curl -X POST http://localhost:8080/api/render \
+   curl -X POST http://localhost:8080/api/workflows/runs \
+     -F 'workflow_id=render' \
      -F 'input.audio=@./song.mp3' \
      -F 'input.fps=30' \
      -F 'input.band_count=48'

--- a/examples/media-processing/audio-spectrum-to-video/README.md
+++ b/examples/media-processing/audio-spectrum-to-video/README.md
@@ -82,7 +82,8 @@ Have an audio file ready (mp3, wav, flac, ogg, opus, or aac).
    Via the Gradio UI at http://localhost:8081, or via HTTP:
 
    ```bash
-   curl -X POST http://localhost:8080/api/render \
+   curl -X POST http://localhost:8080/api/workflows/runs \
+     -F 'workflow_id=render' \
      -F 'input.audio=@./song.mp3' \
      -F 'input.fps=30' \
      -F 'input.band_count=48'

--- a/examples/media-processing/audio-spectrum-to-video/README.zh-cn.md
+++ b/examples/media-processing/audio-spectrum-to-video/README.zh-cn.md
@@ -77,7 +77,8 @@ cd examples/media-processing/audio-spectrum-to-video
    通过 http://localhost:8081 的 Gradio UI 或 HTTP：
 
    ```bash
-   curl -X POST http://localhost:8080/api/render \
+   curl -X POST http://localhost:8080/api/workflows/runs \
+     -F 'workflow_id=render' \
      -F 'input.audio=@./song.mp3' \
      -F 'input.fps=30' \
      -F 'input.band_count=48'

--- a/examples/media-processing/html-animation-to-video/README.ko.md
+++ b/examples/media-processing/html-animation-to-video/README.ko.md
@@ -59,9 +59,9 @@ cd examples/media-processing/html-animation-to-video
    http://localhost:8081의 Gradio UI 또는 HTTP로:
 
    ```bash
-   curl -X POST http://localhost:8080/api/render \
+   curl -X POST http://localhost:8080/api/workflows/runs \
      -H 'Content-Type: application/json' \
-     -d '{"input": {"fps": 30}}'
+     -d '{"workflow_id": "render", "input": {"fps": 30}}'
    ```
 
 응답에는 생성된 `.mp4`의 경로가 포함됩니다.

--- a/examples/media-processing/html-animation-to-video/README.md
+++ b/examples/media-processing/html-animation-to-video/README.md
@@ -60,9 +60,9 @@ cd examples/media-processing/html-animation-to-video
    Via the Gradio UI at http://localhost:8081, or via HTTP:
 
    ```bash
-   curl -X POST http://localhost:8080/api/render \
+   curl -X POST http://localhost:8080/api/workflows/runs \
      -H 'Content-Type: application/json' \
-     -d '{"input": {"fps": 30}}'
+     -d '{"workflow_id": "render", "input": {"fps": 30}}'
    ```
 
 The response contains a path to the produced `.mp4`.

--- a/examples/media-processing/html-animation-to-video/README.zh-cn.md
+++ b/examples/media-processing/html-animation-to-video/README.zh-cn.md
@@ -59,9 +59,9 @@ cd examples/media-processing/html-animation-to-video
    通过 http://localhost:8081 的 Gradio UI 或 HTTP：
 
    ```bash
-   curl -X POST http://localhost:8080/api/render \
+   curl -X POST http://localhost:8080/api/workflows/runs \
      -H 'Content-Type: application/json' \
-     -d '{"input": {"fps": 30}}'
+     -d '{"workflow_id": "render", "input": {"fps": 30}}'
    ```
 
 响应中包含生成的 `.mp4` 路径。


### PR DESCRIPTION
The curl examples in the `audio-spectrum-to-video` and `html-animation-to-video` READMEs (en/ko/zh-cn) still POST to `/api/render`, which no longer exists. Update them to the current `/api/workflows/runs` endpoint with an explicit `workflow_id`.

- `examples/media-processing/audio-spectrum-to-video/README.md`, `README.ko.md`, `README.zh-cn.md`
- `examples/media-processing/html-animation-to-video/README.md`, `README.ko.md`, `README.zh-cn.md`
