### PR TITLE
Return the response when an http action has no completion stage

### DIFF
--- a/src/mindor/core/component/services/http_client.py
+++ b/src/mindor/core/component/services/http_client.py
@@ -117,6 +117,8 @@ class HttpClientAction:
 
         context.register_source("response", response)
 
+        result = None
+
         if self.completion:
             is_direct_output = not self.config.output or self.config.output == "${result}"
 
@@ -132,7 +134,7 @@ class HttpClientAction:
 
             context.register_source("result", result)
 
-        return (await context.render_variable(self.config.output)) if not is_direct_output else (result or response)
+        return (await context.render_variable(self.config.output)) if not is_direct_output else (result if self.completion else response)
 
     async def _resolve_url_or_path(self, context: ComponentActionContext) -> str:
         if self.config.path:

--- a/src/mindor/core/component/services/http_server.py
+++ b/src/mindor/core/component/services/http_server.py
@@ -110,6 +110,8 @@ class HttpServerAction:
 
         context.register_source("response", response)
 
+        result = None
+
         if self.completion:
             is_direct_output = not self.config.output or self.config.output == "${result}"
 
@@ -125,7 +127,7 @@ class HttpServerAction:
 
             context.register_source("result", result)
 
-        return (await context.render_variable(self.config.output)) if not is_direct_output else (result or response)
+        return (await context.render_variable(self.config.output)) if not is_direct_output else (result if self.completion else response)
 
     async def _resolve_body(self, context: ComponentActionContext) -> Any:
         body = await context.render_variable(self.config.body)


### PR DESCRIPTION
`HttpClientAction.run` binds `result` only inside its `if self.completion` branch but reads it from the return statement outside, so any action with no `completion` block and no `output` mapping raised `UnboundLocalError` instead of returning its response — the plain `http-client` GET that the `youtube-to-playlist-video` example points at YouTube's oEmbed endpoint among them. Binding `result` up front and selecting on `self.completion` rather than on `result or response` also keeps a completion that legitimately resolves to `""`, `0`, or `{}` from being replaced by the initial response. `HttpServerAction.run` carried the same two lines and gets the same fix.