### PR TITLE
Fix stereo audio decoded as mono when a sample rate is requested

### DIFF
--- a/src/mindor/core/foundation/streaming/audio.py
+++ b/src/mindor/core/foundation/streaming/audio.py
@@ -496,7 +496,13 @@ class AudioDecodingStreamer:
             async for chunk in stream:
                 yield chunk
 
-        return _stream(), stream.attrs
+        # Advertise the layout this pass-through actually resolves to, defaults
+        # filled in. A partially-declared source (say ``sample_rate`` but no
+        # ``channels``) would otherwise leave consumers waiting on a key that no
+        # amount of reading will ever produce — these bytes carry no header.
+        attrs = { **stream.attrs, "sample_rate": source_sample_rate, "channels": source_channels }
+
+        return _stream(), attrs
 
     @staticmethod
     def _is_torchaudio_available() -> bool:
@@ -629,10 +635,15 @@ class AudioBufferStreamer:
         # header (or the torchaudio decode result) as its first chunks stream
         # in. Prime the iterator so the layout is resolved before
         # ``_create_stream_context`` reads sr/channels.
+        #
+        # Both keys have to be waited on, not just ``sample_rate``: the ffmpeg
+        # path pre-fills ``sample_rate`` when the caller requested one, so
+        # keying off it alone would skip priming entirely and leave
+        # ``channels`` unset — silently decoding stereo as mono.
         source_iterator = aiter(source)
         primed_chunks: List[bytes] = []
         try:
-            while "sample_rate" not in source.attrs:
+            while "sample_rate" not in source.attrs or "channels" not in source.attrs:
                 primed_chunks.append(await anext(source_iterator))
         except StopAsyncIteration:
             pass

--- a/tests/unit/core/foundation/streaming/test_audio.py
+++ b/tests/unit/core/foundation/streaming/test_audio.py
@@ -8,6 +8,7 @@ Covers:
 
 from __future__ import annotations
 
+import asyncio
 import io
 import wave
 
@@ -262,6 +263,46 @@ class TestCollectCompressed:
         assert buffer.waveform.dtype == np.float32
         # ~half length; allow tolerance for filter tail
         assert 1500 <= buffer.waveform.shape[-1] <= 1700
+
+    @pytest.mark.anyio
+    async def test_wav_container_explicit_rate_keeps_stereo_layout(self):
+        # Regression: an explicit ``sample_rate`` makes the decoder pre-fill
+        # ``attrs["sample_rate"]``. Priming used to stop on that key alone, so
+        # the decoded WAV header was never read and ``channels`` stayed unset.
+        # The interleaved stereo stream was then decoded as mono, doubling the
+        # frame count and folding both channels into one signal.
+        left = np.full(1600, 1000, dtype=np.int16)
+        right = np.full(1600, 3000, dtype=np.int16)
+        wav_bytes = build_wav_bytes(np.stack([left, right], axis=0), sample_rate=16000, channels=2)
+        src = MediaSource(BytesStreamResource(wav_bytes), format="wav")
+
+        buffer = await AudioBufferStreamer(src, sample_rate=16000).collect()
+
+        assert buffer.sample_rate == 16000
+        assert buffer.waveform.shape == (2, 1600)
+        assert np.allclose(buffer.waveform[0], 1000.0 / 32768.0, atol=1e-4)
+        assert np.allclose(buffer.waveform[1], 3000.0 / 32768.0, atol=1e-4)
+
+    @pytest.mark.anyio
+    async def test_wav_container_resample_keeps_stereo_layout(self):
+        # Same regression with resampling on: a wrong channel count also builds
+        # the resampler for the wrong layout, so the output is checked for both
+        # shape and per-channel content.
+        left = np.full(3200, 1000, dtype=np.int16)
+        right = np.full(3200, 3000, dtype=np.int16)
+        wav_bytes = build_wav_bytes(np.stack([left, right], axis=0), sample_rate=32000, channels=2)
+        src = MediaSource(BytesStreamResource(wav_bytes), format="wav")
+
+        buffer = await AudioBufferStreamer(src, sample_rate=16000).collect()
+
+        assert buffer.sample_rate == 16000
+        assert buffer.waveform.ndim == 2
+        assert buffer.waveform.shape[0] == 2
+        # ~half length; allow tolerance for filter tail
+        assert 1500 <= buffer.waveform.shape[1] <= 1700
+        # Steady-state level per channel, skipping the resampler's edge ramps.
+        assert np.allclose(buffer.waveform[0, 100:-100], 1000.0 / 32768.0, atol=1e-3)
+        assert np.allclose(buffer.waveform[1, 100:-100], 3000.0 / 32768.0, atol=1e-3)
 
 
 # ---- AudioBufferStreamer ----
@@ -601,6 +642,36 @@ class TestStreamAudioArrayValidation:
         with pytest.raises(RuntimeError, match="ffmpeg audio decoding failed"):
             async for _ in AudioBufferStreamer(src, 512):
                 pass
+
+    @pytest.mark.anyio
+    async def test_partially_declared_pcm_source_does_not_stall(self):
+        # A pass-through PCM source declaring only ``sample_rate`` must still
+        # produce frames. Waiting for a complete layout to arrive from the
+        # stream would block forever here: raw PCM carries no header, so the
+        # missing ``channels`` never shows up and an endless capture would be
+        # buffered without ever emitting.
+        class EndlessPcm(StreamResource):
+            def __init__(self):
+                super().__init__("audio/pcm", None)
+
+            async def close(self) -> None:
+                pass
+
+            async def _iterate_stream(self):
+                block = np.zeros(1600, dtype="<i2").tobytes()
+                while True:
+                    await asyncio.sleep(0)
+                    yield block
+
+        attrs = {"sample_rate": 16000}
+        pcm = PcmStreamResource(EndlessPcm(), attrs=attrs)
+        src = MediaSource(pcm, format=pcm.format, attrs=attrs)
+
+        frames = aiter(AudioBufferStreamer(src, 512, sample_rate=16000))
+        buffer = await asyncio.wait_for(anext(frames), timeout=5.0)
+
+        # Undeclared channel count falls back to mono, as it always has.
+        assert buffer.waveform.shape == (512,)
 
 
 class TestStreamAudioArrayFloat32Source:

--- a/tests/unit/core/foundation/streaming/test_audio_decoding_streamer.py
+++ b/tests/unit/core/foundation/streaming/test_audio_decoding_streamer.py
@@ -90,6 +90,21 @@ class TestPassThrough:
         assert data == pcm_bytes
 
     @pytest.mark.anyio
+    async def test_passthrough_completes_partially_declared_attrs(self):
+        # Raw PCM carries no header, so whatever the source declares is all a
+        # consumer will ever get. Report the layout the pass-through actually
+        # resolves to, defaults included, rather than a half-filled dict.
+        samples = make_sine_int16(440.0, 16000, 0.05)
+        pcm = PcmStreamResource(BytesStreamResource(samples.tobytes()), attrs={"sample_rate": 16000})
+        source = MediaSource(pcm, format=pcm.format, attrs={"sample_rate": 16000})
+
+        out = AudioDecodingStreamer(source, sample_rate=16000).as_pcm_stream()
+
+        assert out.attrs["sample_rate"] == 16000
+        assert out.attrs["channels"] == 1
+        assert await collect_bytes(out) == samples.tobytes()
+
+    @pytest.mark.anyio
     async def test_raw_pcm_with_matching_target_still_passes_through(self):
         samples = make_sine_int16(440.0, 16000, 0.05)
         pcm_bytes = samples.tobytes()


### PR DESCRIPTION
## Problem

`music-source-separation` returns stems that are twice as long as the input, an octave low, and effectively mono. On a 4:27 track the six stems each came back as 8:55 of audio.

The cause is not in the task — it is in `AudioBufferStreamer`, and it silently corrupts any caller that asks for a sample rate while keeping the source channel layout.

## Root cause

`src/mindor/core/foundation/streaming/audio.py`

1. `_decode_with_ffmpeg` pre-fills `attrs["sample_rate"]` as soon as the caller pins a rate, before any bytes are read. `attrs["channels"]` is only filled later, when the decoded WAV header is parsed.
2. `AudioBufferStreamer._iterate` primes the stream so the layout is resolved before `_create_stream_context` reads it — but the loop keyed off `sample_rate` alone:
   ```python
   while "sample_rate" not in source.attrs:
       primed_chunks.append(await anext(source_iterator))
   ```
   That key is already present, so priming never ran, the header was never parsed, and `channels` never arrived.
3. `_create_stream_context` then fell back to `source.attrs.get("channels", 1)` → **1**, decoding an interleaved stereo stream as a single mono signal.

The trigger is **explicit `sample_rate` + `channel=None` + a multi-channel source**. `music-source-separation` uses exactly that combination — both `demucs.py` and `mdx_net.py` call `AudioBufferStreamer(audio, sample_rate=self.model_sample_rate)`. Callers passing `channel="mono"` were never affected, because that pre-fills `channels` too.

Minimal reproduction on `main`:

```python
import asyncio
from mindor.core.foundation.streaming.media import create_media_source
from mindor.core.foundation.streaming.audio import AudioBufferStreamer

async def main():
    src = create_media_source("stereo-44100.wav")   # 267.42 s
    buf = await AudioBufferStreamer(src, sample_rate=44100).collect()
    print(buf.waveform.shape, buf.waveform.shape[-1] / buf.sample_rate)
    # main:  (23586142,)      534.83   <- 1-D, twice the length
    # fixed: (2, 11793071)    267.42

asyncio.run(main())
```

## Changes

**Wait for both keys when priming.** `sample_rate` alone is not enough to know the layout is resolved.

**Report a complete layout from the pass-through.** Waiting on `channels` only works if `channels` is guaranteed to arrive. Raw PCM carries no header, so a pass-through source declaring only `sample_rate` would have stalled the priming loop forever — buffering an endless capture without ever emitting a frame. `_get_passthrough_stream` now reports the layout it actually resolves to, defaults included, rather than forwarding a half-filled dict. This is the layout `_create_stream_context` would have applied anyway, so behaviour for existing callers is unchanged.

## Impact

Measured on a CC BY track whose vocal and instrumental versions share one master, so `mix − instrumental` gives ground-truth vocals (the two align at lag 0):

| | before | after |
|---|---|---|
| output length (267 s input) | 534.83 s | **267.42 s** |
| stem L/R correlation | 0.999998 (mono) | proper stereo |
| additive reconstruction SDR | 15.64 dB | **23.22 dB** |
| vocals SDR | 5.84 dB | **9.13 dB** |
| accompaniment SDR | 6.72 dB | **9.50 dB** |
| vocal bleed into instruments | −13.8 dB | **−21.4 dB** |
| separation time | 123.2 s | **58.1 s** |

It ran twice as slow because it was processing twice as many samples.

## Tests

Four regression tests, each verified to fail without the corresponding change:

- `test_wav_container_explicit_rate_keeps_stereo_layout` — explicit rate + `channel=None` keeps `(2, N)` and per-channel content. Without the fix: `assert 1 == 2`, with the waveform showing both channels interleaved into one signal.
- `test_wav_container_resample_keeps_stereo_layout` — same with resampling on, where a wrong channel count also builds the resampler for the wrong layout.
- `test_partially_declared_pcm_source_does_not_stall` — a pass-through PCM source declaring only `sample_rate` still emits its first frame. Without the pass-through change: times out.
- `test_passthrough_completes_partially_declared_attrs` — the pass-through reports a resolved layout. Without the change: `KeyError`.

`python -m pytest tests/` was run on this branch and on `main`: 3221 passed, and the set of failures is byte-identical between the two, so nothing new breaks. Those pre-existing failures all need optional dependencies or external services that are not available locally.

Also verified end to end against a real 4-minute stereo track across six layout combinations — explicit rate, no rate, `channel="mono"`, `channel=1`, downsampling to 22050, and mp3 input — all producing the expected shape and duration.
