### PR TITLE
fix(image-background-removal): resolve UnboundLocalError in streaming output generator

### DIFF
--- a/src/mindor/core/component/services/model/tasks/image_background_removal/common.py
+++ b/src/mindor/core/component/services/model/tasks/image_background_removal/common.py
@@ -32,10 +32,10 @@ class ImageBackgroundRemovalTaskAction(ComponentAction):
         if isinstance(image, (StreamIterator, AsyncIterator)):
             async def _stream_output_generator():
                 async for batch_images in BatchSourceIterator(image, batch_size=batch_size or 1):
-                    batch_images = [ self._normalize_image(image) for image in batch_images ]
+                    batch_images = [ self._normalize_image(img) for img in batch_images ]
                     batch_masks = await self._predict_masks_batch(batch_images, params, context.cancellation_token)
-                    for image, mask in zip(batch_images, batch_masks):
-                        yield self._render_output(image, mask, params["output_format"])
+                    for img, mask in zip(batch_images, batch_masks):
+                        yield self._render_output(img, mask, params["output_format"])
 
             return _stream_output_generator()
         else:


### PR DESCRIPTION
### Problem

In the streaming branch of `ImageBackgroundRemovalTaskAction.run()` (`src/mindor/core/component/services/model/tasks/image_background_removal/common.py`), the nested `_stream_output_generator` reuses the name `image` as a comprehension/loop variable:

```python
async def _stream_output_generator():
    async for batch_images in BatchSourceIterator(image, batch_size=batch_size or 1):  # reads enclosing `image`
        batch_images = [ self._normalize_image(image) for image in batch_images ]      # rebinds `image`
        for image, mask in zip(batch_images, batch_masks):                             # rebinds `image`
            yield self._render_output(image, mask, params["output_format"])
```

Because `image` is assigned inside the generator, Python treats it as a **local** for the whole generator scope. The `BatchSourceIterator(image, ...)` reference at the top therefore hits the local before it is assigned and raises:

```
UnboundLocalError: cannot access local variable 'image' where it is not associated with a value
```

This means **every streaming input** (`StreamIterator` / `AsyncIterator`, i.e. the `isinstance(image, (StreamIterator, AsyncIterator))` path) fails as soon as the returned generator is iterated. The non-streaming `else` branch is unaffected, since there `image` is a genuine local of `run()` assigned earlier.

### Fix

Rename the inner loop variables to `img` so the enclosing source `image` stays reachable inside the generator. Pure rename, no behavioral change other than fixing the crash.

### Verification

Minimal reproduction of the scope structure raises `UnboundLocalError` at the `BatchSourceIterator(image, ...)` line before the change and runs cleanly after. `pyflakes` reports `local variable 'image' ... referenced before assignment` on the original file and is clean after the rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
