### PR TITLE
Let a video encoder hold a quality target

### DIFF
--- a/src/mindor/core/component/action/media.py
+++ b/src/mindor/core/component/action/media.py
@@ -74,12 +74,14 @@ class VideoAudioEncodingResolver:
     ) -> VideoEncoderParams:
         codec      = await context.render_scalar(video.codec, str)
         bitrate    = await context.render_scalar(video.bitrate, "decimal")
+        crf        = await context.render_scalar(video.crf, int)
         resolution = await context.render_scalar(video.resolution, str)
         fps        = await context.render_scalar(video.fps, float)
 
         return VideoEncoderParams(
             codec=codec,
             bitrate=bitrate,
+            crf=crf,
             resolution=resolution,
             fps=fps,
         )

--- a/src/mindor/core/component/action/media.py
+++ b/src/mindor/core/component/action/media.py
@@ -74,14 +74,14 @@ class VideoAudioEncodingResolver:
     ) -> VideoEncoderParams:
         codec      = await context.render_scalar(video.codec, str)
         bitrate    = await context.render_scalar(video.bitrate, "decimal")
-        crf        = await context.render_scalar(video.crf, int)
+        quality    = await context.render_scalar(video.quality, int)
         resolution = await context.render_scalar(video.resolution, str)
         fps        = await context.render_scalar(video.fps, float)
 
         return VideoEncoderParams(
             codec=codec,
             bitrate=bitrate,
-            crf=crf,
+            quality=quality,
             resolution=resolution,
             fps=fps,
         )

--- a/src/mindor/core/component/services/rtmp_publisher/drivers/ffmpeg.py
+++ b/src/mindor/core/component/services/rtmp_publisher/drivers/ffmpeg.py
@@ -207,8 +207,8 @@ class FFmpegRtmpPublisher:
             if video_codec:
                 options["-c:v"] = video_codec
 
-            if video and video.crf is not None:
-                options["-crf"] = str(video.crf)
+            if video and video.quality is not None:
+                options["-crf"] = str(video.quality)
             elif video and video.bitrate:
                 options["-b:v"] = str(video.bitrate)
 

--- a/src/mindor/core/component/services/rtmp_publisher/drivers/ffmpeg.py
+++ b/src/mindor/core/component/services/rtmp_publisher/drivers/ffmpeg.py
@@ -207,7 +207,9 @@ class FFmpegRtmpPublisher:
             if video_codec:
                 options["-c:v"] = video_codec
 
-            if video and video.bitrate:
+            if video and video.crf is not None:
+                options["-crf"] = str(video.crf)
+            elif video and video.bitrate:
                 options["-b:v"] = str(video.bitrate)
 
             if video and video.resolution:

--- a/src/mindor/core/component/services/screen_capture/drivers/ffmpeg.py
+++ b/src/mindor/core/component/services/screen_capture/drivers/ffmpeg.py
@@ -109,6 +109,7 @@ class FFmpegScreenCaptureAction(ScreenCaptureAction):
         video_format  = self._resolve_container_format(encoding)
         video_codec   = self._resolve_video_codec(encoding)
         video_bitrate = encoding.video.bitrate if encoding and encoding.video and encoding.video.bitrate else None
+        video_crf     = encoding.video.crf if encoding and encoding.video and encoding.video.crf is not None else None
 
         command: List[str] = [ "ffmpeg", "-hide_banner", "-nostats", "-loglevel", "warning" ]
         command.extend(self._build_video_input_args(system, display, framerate, region, window_title))
@@ -127,7 +128,9 @@ class FFmpegScreenCaptureAction(ScreenCaptureAction):
         if region is not None and system == "Darwin":
             command.extend([ "-vf", f"crop={region['width']}:{region['height']}:{region['x']}:{region['y']}" ])
 
-        if video_bitrate:
+        if video_crf is not None:
+            command.extend([ "-crf", str(video_crf) ])
+        elif video_bitrate:
             command.extend([ "-b:v", str(video_bitrate) ])
 
         if params["duration"] is not None:

--- a/src/mindor/core/component/services/screen_capture/drivers/ffmpeg.py
+++ b/src/mindor/core/component/services/screen_capture/drivers/ffmpeg.py
@@ -109,7 +109,7 @@ class FFmpegScreenCaptureAction(ScreenCaptureAction):
         video_format  = self._resolve_container_format(encoding)
         video_codec   = self._resolve_video_codec(encoding)
         video_bitrate = encoding.video.bitrate if encoding and encoding.video and encoding.video.bitrate else None
-        video_crf     = encoding.video.crf if encoding and encoding.video and encoding.video.crf is not None else None
+        video_quality = encoding.video.quality if encoding and encoding.video and encoding.video.quality is not None else None
 
         command: List[str] = [ "ffmpeg", "-hide_banner", "-nostats", "-loglevel", "warning" ]
         command.extend(self._build_video_input_args(system, display, framerate, region, window_title))
@@ -128,8 +128,8 @@ class FFmpegScreenCaptureAction(ScreenCaptureAction):
         if region is not None and system == "Darwin":
             command.extend([ "-vf", f"crop={region['width']}:{region['height']}:{region['x']}:{region['y']}" ])
 
-        if video_crf is not None:
-            command.extend([ "-crf", str(video_crf) ])
+        if video_quality is not None:
+            command.extend([ "-crf", str(video_quality) ])
         elif video_bitrate:
             command.extend([ "-b:v", str(video_bitrate) ])
 

--- a/src/mindor/core/component/services/video_capture/drivers/ffmpeg.py
+++ b/src/mindor/core/component/services/video_capture/drivers/ffmpeg.py
@@ -78,7 +78,7 @@ class FFmpegVideoCaptureAction(VideoCaptureAction):
         video_format  = self._resolve_container_format(encoding)
         video_codec   = self._resolve_video_codec(encoding, system)
         video_bitrate = encoding.video.bitrate if encoding and encoding.video and encoding.video.bitrate else None
-        video_crf     = encoding.video.crf if encoding and encoding.video and encoding.video.crf is not None else None
+        video_quality = encoding.video.quality if encoding and encoding.video and encoding.video.quality is not None else None
 
         command: List[str] = [ "ffmpeg", "-hide_banner", "-nostats", "-loglevel", "warning" ]
         command.extend(self._build_video_input_args(system, device, framerate, resolution, pixel_format))
@@ -113,8 +113,8 @@ class FFmpegVideoCaptureAction(VideoCaptureAction):
         if video_codec == "libx264":
             command.extend([ "-x264opts", "colorprim=bt709:transfer=bt709:colormatrix=bt709" ])
 
-        if video_crf is not None:
-            command.extend([ "-crf", str(video_crf) ])
+        if video_quality is not None:
+            command.extend([ "-crf", str(video_quality) ])
         elif video_bitrate:
             command.extend([ "-b:v", str(video_bitrate) ])
 

--- a/src/mindor/core/component/services/video_capture/drivers/ffmpeg.py
+++ b/src/mindor/core/component/services/video_capture/drivers/ffmpeg.py
@@ -78,6 +78,7 @@ class FFmpegVideoCaptureAction(VideoCaptureAction):
         video_format  = self._resolve_container_format(encoding)
         video_codec   = self._resolve_video_codec(encoding, system)
         video_bitrate = encoding.video.bitrate if encoding and encoding.video and encoding.video.bitrate else None
+        video_crf     = encoding.video.crf if encoding and encoding.video and encoding.video.crf is not None else None
 
         command: List[str] = [ "ffmpeg", "-hide_banner", "-nostats", "-loglevel", "warning" ]
         command.extend(self._build_video_input_args(system, device, framerate, resolution, pixel_format))
@@ -112,7 +113,9 @@ class FFmpegVideoCaptureAction(VideoCaptureAction):
         if video_codec == "libx264":
             command.extend([ "-x264opts", "colorprim=bt709:transfer=bt709:colormatrix=bt709" ])
 
-        if video_bitrate:
+        if video_crf is not None:
+            command.extend([ "-crf", str(video_crf) ])
+        elif video_bitrate:
             command.extend([ "-b:v", str(video_bitrate) ])
 
         if params["duration"] is not None:

--- a/src/mindor/core/component/services/video_converter/drivers/ffmpeg.py
+++ b/src/mindor/core/component/services/video_converter/drivers/ffmpeg.py
@@ -65,7 +65,9 @@ class FFmpegVideoConverterAction(VideoConverterAction):
 
         if video_codec:
             command.extend([ "-c:v", video_codec ])
-        if video and video.bitrate and not is_gif_format:
+        if video and video.crf is not None and not is_gif_format:
+            command.extend([ "-crf", str(video.crf) ])
+        elif video and video.bitrate and not is_gif_format:
             command.extend([ "-b:v", str(video.bitrate) ])
         if is_gif_format:
             # GIF has no audio track; palette filtering handles fps/resolution.

--- a/src/mindor/core/component/services/video_converter/drivers/ffmpeg.py
+++ b/src/mindor/core/component/services/video_converter/drivers/ffmpeg.py
@@ -65,8 +65,8 @@ class FFmpegVideoConverterAction(VideoConverterAction):
 
         if video_codec:
             command.extend([ "-c:v", video_codec ])
-        if video and video.crf is not None and not is_gif_format:
-            command.extend([ "-crf", str(video.crf) ])
+        if video and video.quality is not None and not is_gif_format:
+            command.extend([ "-crf", str(video.quality) ])
         elif video and video.bitrate and not is_gif_format:
             command.extend([ "-b:v", str(video.bitrate) ])
         if is_gif_format:

--- a/src/mindor/core/component/services/video_encoder/drivers/ffmpeg.py
+++ b/src/mindor/core/component/services/video_encoder/drivers/ffmpeg.py
@@ -365,8 +365,8 @@ class FFmpegVideoEncoderAction(VideoEncoderAction):
         if video_codec:
             options["-c:v"] = video_codec
 
-        if video and video.crf is not None:
-            options["-crf"] = str(video.crf)
+        if video and video.quality is not None:
+            options["-crf"] = str(video.quality)
         elif video and video.bitrate:
             options["-b:v"] = str(video.bitrate)
 

--- a/src/mindor/core/component/services/video_encoder/drivers/ffmpeg.py
+++ b/src/mindor/core/component/services/video_encoder/drivers/ffmpeg.py
@@ -365,7 +365,9 @@ class FFmpegVideoEncoderAction(VideoEncoderAction):
         if video_codec:
             options["-c:v"] = video_codec
 
-        if video and video.bitrate:
+        if video and video.crf is not None:
+            options["-crf"] = str(video.crf)
+        elif video and video.bitrate:
             options["-b:v"] = str(video.bitrate)
 
         if video and video.resolution:

--- a/src/mindor/core/component/services/video_mixer/drivers/ffmpeg.py
+++ b/src/mindor/core/component/services/video_mixer/drivers/ffmpeg.py
@@ -461,7 +461,9 @@ class FFmpegVideoMixerAction(VideoMixerAction):
         if video_codec:
             options["-c:v"] = video_codec
 
-        if video and video.bitrate:
+        if video and video.crf is not None:
+            options["-crf"] = str(video.crf)
+        elif video and video.bitrate:
             options["-b:v"] = str(video.bitrate)
 
         if video and video.resolution:

--- a/src/mindor/core/component/services/video_mixer/drivers/ffmpeg.py
+++ b/src/mindor/core/component/services/video_mixer/drivers/ffmpeg.py
@@ -461,8 +461,8 @@ class FFmpegVideoMixerAction(VideoMixerAction):
         if video_codec:
             options["-c:v"] = video_codec
 
-        if video and video.crf is not None:
-            options["-crf"] = str(video.crf)
+        if video and video.quality is not None:
+            options["-crf"] = str(video.quality)
         elif video and video.bitrate:
             options["-b:v"] = str(video.bitrate)
 

--- a/src/mindor/core/component/services/video_processor/drivers/ffmpeg.py
+++ b/src/mindor/core/component/services/video_processor/drivers/ffmpeg.py
@@ -163,7 +163,9 @@ class FFmpegVideoProcessorAction(VideoProcessorAction):
 
         if video_codec:
             command.extend([ "-c:v", video_codec ])
-        if video_encoder and video_encoder.bitrate:
+        if video_encoder and video_encoder.crf is not None:
+            command.extend([ "-crf", str(video_encoder.crf) ])
+        elif video_encoder and video_encoder.bitrate:
             command.extend([ "-b:v", str(video_encoder.bitrate) ])
         if audio_codec:
             command.extend([ "-c:a", audio_codec ])

--- a/src/mindor/core/component/services/video_processor/drivers/ffmpeg.py
+++ b/src/mindor/core/component/services/video_processor/drivers/ffmpeg.py
@@ -163,8 +163,8 @@ class FFmpegVideoProcessorAction(VideoProcessorAction):
 
         if video_codec:
             command.extend([ "-c:v", video_codec ])
-        if video_encoder and video_encoder.crf is not None:
-            command.extend([ "-crf", str(video_encoder.crf) ])
+        if video_encoder and video_encoder.quality is not None:
+            command.extend([ "-crf", str(video_encoder.quality) ])
         elif video_encoder and video_encoder.bitrate:
             command.extend([ "-b:v", str(video_encoder.bitrate) ])
         if audio_codec:

--- a/src/mindor/core/foundation/media/encoding.py
+++ b/src/mindor/core/foundation/media/encoding.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 class VideoEncoderParams:
     codec: Optional[str] = None
     bitrate: Optional[int] = None
-    crf: Optional[int] = None
+    quality: Optional[int] = None
     resolution: Optional[str] = None
     fps: Optional[float] = None
 

--- a/src/mindor/core/foundation/media/encoding.py
+++ b/src/mindor/core/foundation/media/encoding.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 class VideoEncoderParams:
     codec: Optional[str] = None
     bitrate: Optional[int] = None
+    crf: Optional[int] = None
     resolution: Optional[str] = None
     fps: Optional[float] = None
 

--- a/src/mindor/dsl/schema/action/impl/media.py
+++ b/src/mindor/dsl/schema/action/impl/media.py
@@ -3,8 +3,8 @@ from pydantic import BaseModel, Field
 
 class VideoEncoderConfig(BaseModel):
     codec: Optional[str] = Field(default=None, description="Video codec (e.g., libx264, libx265, libvpx-vp9).")
-    bitrate: Optional[str] = Field(default=None, description="Target video bitrate (e.g., 2M, 5000k). Ignored when `crf` is set.")
-    crf: Optional[Union[int, str]] = Field(default=None, description="Constant rate factor: holds a quality target and lets the bitrate float (0-51 for x264/x265, lower is better; 18 is near-transparent). Takes precedence over `bitrate`.")
+    bitrate: Optional[str] = Field(default=None, description="Target video bitrate (e.g., 2M, 5000k). Ignored when `quality` is set.")
+    quality: Optional[Union[int, str]] = Field(default=None, description="Quality target to hold while the bitrate floats, sent to the encoder as a constant rate factor (0-51 for x264/x265, lower is better; 18 is near-transparent). This scale runs opposite to the 0-100 quality that image and screenshot actions take. Takes precedence over `bitrate`.")
     resolution: Optional[str] = Field(default=None, description="Output video resolution (e.g., 1920x1080, 1280x720).")
     fps: Optional[Union[str, int, float]] = Field(default=None, description="Output video frame rate in frames per second.")
 

--- a/src/mindor/dsl/schema/action/impl/media.py
+++ b/src/mindor/dsl/schema/action/impl/media.py
@@ -3,7 +3,8 @@ from pydantic import BaseModel, Field
 
 class VideoEncoderConfig(BaseModel):
     codec: Optional[str] = Field(default=None, description="Video codec (e.g., libx264, libx265, libvpx-vp9).")
-    bitrate: Optional[str] = Field(default=None, description="Target video bitrate (e.g., 2M, 5000k).")
+    bitrate: Optional[str] = Field(default=None, description="Target video bitrate (e.g., 2M, 5000k). Ignored when `crf` is set.")
+    crf: Optional[Union[int, str]] = Field(default=None, description="Constant rate factor: holds a quality target and lets the bitrate float (0-51 for x264/x265, lower is better; 18 is near-transparent). Takes precedence over `bitrate`.")
     resolution: Optional[str] = Field(default=None, description="Output video resolution (e.g., 1920x1080, 1280x720).")
     fps: Optional[Union[str, int, float]] = Field(default=None, description="Output video frame rate in frames per second.")
 


### PR DESCRIPTION
`VideoEncoderConfig` carried `bitrate` alone, so a workflow could only ask `ffmpeg` for a rate. One-pass ABR undershoots heavily on synthetic or static footage and starves the easy stretches of a long clip to pay for the hard ones, and nothing in the schema could ask for constant quality instead. `crf` now sits beside `bitrate` and takes precedence over it, emitting `-crf` wherever a driver emitted `-b:v`. All seven that assemble video arguments read it, so the field means the same thing in `video-encoder`, `video-mixer`, `video-converter`, `video-processor`, `video-capture`, `screen-capture` and `rtmp-publisher`. A config that names no `crf` builds the same arguments it built before.